### PR TITLE
Add climateR to data package table

### DIFF
--- a/08-read-write-plot.Rmd
+++ b/08-read-write-plot.Rmd
@@ -84,7 +84,8 @@ datapackages = tibble::tribble(
   "osmextract", "Download and import large OpenStreetMap datasets.",
   "geodata", "Download and import imports administrative, elevation, WorldClim data.",
   "rnaturalearth", "Access to Natural Earth vector and raster data.",
-  "rnoaa", "Imports National Oceanic and Atmospheric Administration (NOAA) climate data."
+  "rnoaa", "Imports National Oceanic and Atmospheric Administration (NOAA) climate data.",
+  "climateR", "Access gridded climate and landscape data by Area of Interest."
 )
 knitr::kable(datapackages, 
              caption = "Selected R packages for geographic data retrieval.", 


### PR DESCRIPTION
Hi @Nowosad,

I added climateR to the data package table in section 8.3 per https://github.com/mikejohnson51/climateR/issues/44.

Please let me know if you would like an example in the text following the table for climate data, DEMs, soil data or MODIS/NLDAS/GLDAS access.

Thanks again for the opportunity and this excellent resource,

Mike