### PR TITLE
Seems select does not need dplyr prefix?

### DIFF
--- a/03-attribute-operations.Rmd
+++ b/03-attribute-operations.Rmd
@@ -414,7 +414,7 @@ The following command calculates population density (with `mutate()`), arranges 
 ```{r 03-attribute-operations-30}
 world_agg5 = world |> 
   st_drop_geometry() |>                      # drop the geometry for speed
-  dplyr::select(pop, continent, area_km2) |> # subset the columns of interest  
+  select(pop, continent, area_km2) |> # subset the columns of interest  
   group_by(continent) |>                     # group by continent and summarize:
   summarize(Pop = sum(pop, na.rm = TRUE), Area = sum(area_km2), N = n()) |>
   mutate(Density = round(Pop / Area)) |>     # calculate population density
@@ -677,7 +677,6 @@ grain = rast(nrows = 6, ncols = 6,
 elev = rast(system.file("raster/elev.tif", package = "spData"))
 grain = rast(system.file("raster/grain.tif", package = "spData"))
 ```
-
 
 \index{categorical raster}
 \index{raster attribute table}


### PR DESCRIPTION
It seems a recent commit removed "tidyr::" prefix from select(), hence remove it in  this line as well.

There still are "tidyr::" in line 592, 601, 791.

Additionally, removed an unnecessary blank line. 