### PR TITLE
Update _04-ex.Rmd

### DIFF
--- a/_04-ex.Rmd
+++ b/_04-ex.Rmd
@@ -4,7 +4,7 @@ library(dplyr)
 library(spData)
 ```
 
-E1. It was established in Section \@ref(spatial-vec) that Canterbury was the region of New Zealand containing most of the 100 highest points in the country.
+E1. It was established in Section \@ref(spatial-vec) that Canterbury was the region of New Zealand containing most of the 101 highest points in the country.
 How many of these high points does the Canterbury region contain?
 
 **Bonus:** plot the result using the `plot()` function to show all of New Zealand, `canterbury` region highlighted in yellow, high points in Canterbury represented by red crosses (hint: `pch = 7`) and high points in other parts of New Zealand represented by blue circles. See the help page `?points` for details with an illustration of different `pch` values.
@@ -33,7 +33,7 @@ nz_height_combined |>
   slice(2)
 ```
 
-E3. Generalizing the question to all regions: how many of New Zealand's 16 regions contain points which belong to the top 100 highest points in the country? Which regions?
+E3. Generalizing the question to all regions: how many of New Zealand's 16 regions contain points which belong to the top 101 highest points in the country? Which regions?
 
 - Bonus: create a table listing these regions in order of the number of points and their name.
 


### PR DESCRIPTION
- fix typo: nz_height contains 101 highest points in New Zealand
- source: https://www.rdocumentation.org/packages/spData/versions/2.3.0/topics/nz_height