### PR TITLE
remove duplicate 'or not'

### DIFF
--- a/04-spatial-operations.Rmd
+++ b/04-spatial-operations.Rmd
@@ -148,7 +148,7 @@ waldo::compare(canterbury_height2, canterbury_height4)
 At this point, there are three identical (in all but row names) versions of `canterbury_height`, one created using the `[` operator, one created via an intermediary selection object, and another using **sf**'s convenience function `st_filter()`.
 <!-- RL: commented out for now as old. Todo: if we ever update that vignette uncomment the next line. -->
 <!-- To explore spatial subsetting in more detail, see the supplementary vignettes on `subsetting` and [`tidyverse-pitfalls`](https://geocompr.github.io/geocompkg/articles/) on the [geocompkg website](https://geocompr.github.io/geocompkg/articles/). -->
-The next section explores different types of spatial relation, also known as binary predicates, that can be used to identify whether or not two features are spatially related or not.
+The next section explores different types of spatial relation, also known as binary predicates, that can be used to identify whether two features are spatially related or not.
 
 ### Topological relations
 


### PR DESCRIPTION
The original text had a duplicate 'or not' at different places in the same sentence. This should be clearer. 