### PR TITLE
Update 04-spatial-operations.Rmd: fix small typo in text

### DIFF
--- a/04-spatial-operations.Rmd
+++ b/04-spatial-operations.Rmd
@@ -799,7 +799,7 @@ Areal interpolation overcomes this issue by transferring values from one set of 
 source("code/04-areal-example.R", print.eval = TRUE)
 ```
 
-The **spData** package contains a dataset named `incongruent` (colored polygons with black borders in the right panel of Figure \@ref(fig:areal-example)) and a dataset named `aggregating_zones` (the two polygons with the translucent blue border in the right panel of Figure \@ref(fig:areal-example)).
+The **spData** package contains a dataset named `incongruent` (colored polygons with black borders in the right panel of Figure \@ref(fig:areal-example)) and a dataset named `aggregating_zones` (the two polygons with the translucent red border in the right panel of Figure \@ref(fig:areal-example)).
 Let us assume that the `value` column of `incongruent` refers to the total regional income in million Euros.
 How can we transfer the values of the underlying nine spatial polygons into the two polygons of `aggregating_zones`?
 


### PR DESCRIPTION
Typo in color: should be "red" not "blue" to match map and map description.