### PR TITLE
Update 04-spatial-operations.Rmd - Fig 4.10 refers to different code …

### DIFF
--- a/04-spatial-operations.Rmd
+++ b/04-spatial-operations.Rmd
@@ -853,11 +853,7 @@ elev[clip]
 # terra::extract(elev, ext(clip))
 ```
 
-This amounts to retrieving the values of the first raster object (in this case `elev`) that fall within the extent of a second raster (here: `clip`), as illustrated in Figure \@ref(fig:raster-subset).
-
-```{r raster-subset, echo = FALSE, fig.cap = "Original raster (left), raster mask (middle), and output of masking a raster (right).", fig.scap="Subsetting raster values."}
-knitr::include_graphics("images/04_raster_subset.png")
-```
+This amounts to retrieving the values of the first raster object (in this case `elev`) that fall within the extent of a second raster (here: `clip`).
 
 The example above returned the values of specific cells, but in many cases spatial outputs from subsetting operations on raster datasets are needed.
 This can be done by setting the `drop` argument of the `[` operator to `FALSE`.
@@ -878,6 +874,10 @@ plot(x)
 
 Another common use case of spatial subsetting is when a raster with `logical` (or `NA`) values is used to mask another raster with the same extent and resolution, as illustrated in Figure \@ref(fig:raster-subset).
 In this case, the `[` and `mask()` functions can be used (results not shown).
+
+```{r raster-subset, echo = FALSE, fig.cap = "Original raster (left), raster mask (middle), and output of masking a raster (right).", fig.scap="Subsetting raster values."}
+knitr::include_graphics("images/04_raster_subset.png")
+```
 
 ```{r 04-spatial-operations-38, eval=FALSE}
 # create raster mask


### PR DESCRIPTION
…chunk example

Fig 4.10 refers to the masking, not the subsetting code chunk example.  Removed reference and moved figure slightly down.