### PR TITLE
Remove SAGA NextGen plugin references (repo deleted upstream)

### DIFF
--- a/10-gis.Rmd
+++ b/10-gis.Rmd
@@ -384,8 +384,7 @@ dem = system.file("raster/dem.tif", package = "spDataLarge")
 The **terra** package's `terrain()` command already allows the calculation of several fundamental topographic characteristics such as slope, aspect, TPI (*Topographic Position Index*), TRI (*Topographic Ruggedness Index*), roughness, and flow directions.
 However, GIS programs offer many more terrain characteristics, some of which can be more suitable in certain contexts.
 For example, the topographic wetness index (TWI)\index{topographic wetness index} was found useful in studying hydrological and biological processes [@sorensen_calculation_2006].
-TWI can be calculated with the GRASS GIS function `r.topidx`.
-More terrain analysis algorithms from SAGA were previously available via the `sagang:` provider, but the bridge plugin required for this has been removed (see [issue #1181](https://github.com/geocompx/geocompr/issues/1181)).
+TWI can be calculated with the GRASS GIS function `r.topidx`, and functionality is also available in the SAGA GIS standalone software.
 
 Information from digital elevation models can also be categorized, for example, to geomorphons\index{geomorphons} -- the geomorphological phenotypes consisting of ten classes that represent terrain forms, such as slopes, ridges, or valleys [@jasiewicz_geomorphons_2013].
 These phenotypes are used in many studies, including landslide susceptibility, ecosystem services, human mobility, and digital soil mapping. 

--- a/10-gis.Rmd
+++ b/10-gis.Rmd
@@ -31,8 +31,7 @@ has_qgis_plugins =
   # make sure that QGIS is available
   qgisprocess::has_qgis() &&
   # make sure that all required plugins are available
-   all(qgisprocess::qgis_has_plugin(c("grassprovider", 
-                                      "processing_saga_nextgen")))
+  all(qgisprocess::qgis_has_plugin("grassprovider"))
 ```
 
 ## Introduction
@@ -152,24 +151,19 @@ Next, we can find which plugins (meaning different software) are available on ou
 ```{r plugins, eval=FALSE}
 qgis_plugins()
 #> # A tibble: 4 × 2
-#>   name                    enabled
-#>   <chr>                   <lgl>
-#> 1 grassprovider           FALSE
-#> 2 otbprovider             FALSE
-#> 3 processing              TRUE
-#> 4 processing_saga_nextgen FALSE
+#>   name           enabled
+#>   <chr>          <lgl>
+#> 1 grassprovider  FALSE
+#> 2 otbprovider    FALSE
+#> 3 processing     TRUE
 ```
 
-This tells us that the GRASS GIS (`grassprovider`) and SAGA (`processing_saga_nextgen`) plugins are available on the system but are not yet enabled.
-Since we need both later on in the chapter, let's enable them. 
+This tells us that the GRASS GIS (`grassprovider`) plugin is available on the system but is not yet enabled.
+Since we need it later on in the chapter, let's enable it. 
 
 ```{r enable-providers, eval=FALSE}
-qgis_enable_plugins(c("grassprovider", "processing_saga_nextgen"), 
-                    quiet = TRUE)
+qgis_enable_plugins("grassprovider", quiet = TRUE)
 ```
-
-Please note that aside from installing SAGA on your system, you also need to install the QGIS Python plugin Processing Saga NextGen.
-You can do so from within QGIS with the [Plugin Manager](https://docs.qgis.org/latest/en/docs/training_manual/qgis_plugins/fetching_plugins.html) or programmatically with the help of the Python package [qgis-plugin-manager](https://github.com/3liz/qgis-plugin-manager) (at least on Linux).
 
 `qgis_providers()` lists the name of the software and the corresponding count of available geoalgorithms.
 
@@ -184,10 +178,9 @@ qgis_providers()
 #> 4 3d       QGIS (3D)                       1
 #> 5 native   QGIS (native c++)             243
 #> 6 pdal     QGIS (PDAL)                    17
-#> 7 sagang   SAGA Next Gen                 509
 ```
 
-The output table affirms that we can use QGIS geoalgorithms (`native`, `qgis`, `3d`, `pdal`) and external ones from the third-party providers GDAL, SAGA and GRASS GIS through the QGIS interface.
+The output table affirms that we can use QGIS geoalgorithms (`native`, `qgis`, `3d`, `pdal`) and external ones from the third-party providers GDAL and GRASS GIS through the QGIS interface.
 
 Now, we are ready for some geocomputation with QGIS and friends, from within R!
 Let's try two example case studies.
@@ -391,56 +384,8 @@ dem = system.file("raster/dem.tif", package = "spDataLarge")
 The **terra** package's `terrain()` command already allows the calculation of several fundamental topographic characteristics such as slope, aspect, TPI (*Topographic Position Index*), TRI (*Topographic Ruggedness Index*), roughness, and flow directions.
 However, GIS programs offer many more terrain characteristics, some of which can be more suitable in certain contexts.
 For example, the topographic wetness index (TWI)\index{topographic wetness index} was found useful in studying hydrological and biological processes [@sorensen_calculation_2006].
-Let's search the algorithm list for this index using `"wetness"` as keyword.
-
-```{r, eval=FALSE}
-qgis_search_algorithms("wetness") |>
-  dplyr::select(provider_title, algorithm) |>
-  head(2)
-#> # A tibble: 2 × 2
-#>   provider_title algorithm
-#>   <chr>          <chr>
-#> 1 SAGA Next Gen  sagang:sagawetnessindex
-#> 2 SAGA Next Gen  sagang:topographicwetnessindexonestep
-```
-
-An output of the above code suggests that the desired algorithm exists in the SAGA software\index{SAGA}.^[TWI can be also calculated using the `r.topidx` GRASS GIS function.]
-Though SAGA is a hybrid GIS, its main focus has been on raster processing, and here, particularly on digital elevation models\index{digital elevation model} (soil properties, terrain attributes, climate parameters). 
-Hence, SAGA is especially good at the fast processing of large (high-resolution) raster\index{raster} datasets [@conrad_system_2015].
-
-The `"sagang:sagawetnessindex"` algorithm is actually a modified TWI, that results in a more realistic soil moisture potential for the cells located in valley floors [@bohner_spatial_2006].
-
-```{r, eval=FALSE}
-qgis_show_help("sagang:sagawetnessindex")
-```
-
-Here, we stick with the default values for all arguments.
-Therefore, we only have to specify one argument -- the input `DEM`.
-Of course, when applying this algorithm you should make sure that the parameter values are in correspondence with your study aim.^[The additional arguments of `"sagang:sagawetnessindex"` are well-explained at https://gis.stackexchange.com/a/323454/20955.]
-
-Before running the SAGA algorithm from within QGIS, we change the default raster output format from `.tif` to SAGA's native raster format `.sdat`.
-Hence, all output rasters that we do not specify ourselves will from now on be written to the `.sdat` format. 
-Depending on the software versions (SAGA, GDAL) you are using, this might not be necessary, but often enough this will save you trouble when trying to read-in output rasters created with SAGA.
-
-```{r, eval=FALSE}
-options(qgisprocess.tmp_raster_ext = ".sdat")
-dem_wetness = qgis_run_algorithm("sagang:sagawetnessindex",
-  DEM = dem
-)
-```
-
-`"sagang:sagawetnessindex"` returns not one but four rasters -- catchment area, catchment slope, modified catchment area, and topographic wetness index.
-We can read a selected output by providing an output name in the `qgis_as_terra()` function.
-And since we are done with the SAGA processing from within QGIS, we change the raster output format back to `.tif`.
-
-```{r, eval=FALSE}
-dem_wetness_twi = qgis_as_terra(dem_wetness$TWI)
-# plot(dem_wetness_twi)
-options(qgisprocess.tmp_raster_ext = ".tif")
-```
-
-You can see the TWI map in the left panel of Figure \@ref(fig:qgis-raster-map).
-The topographic wetness index is unitless: its low values represent areas that will not accumulate water, while higher values show areas that will accumulate water at increasing levels.
+TWI can be calculated with the GRASS GIS function `r.topidx`.
+More terrain analysis algorithms from SAGA were previously available via the `sagang:` provider, but the bridge plugin required for this has been removed (see [issue #1181](https://github.com/geocompx/geocompr/issues/1181)).
 
 Information from digital elevation models can also be categorized, for example, to geomorphons\index{geomorphons} -- the geomorphological phenotypes consisting of ten classes that represent terrain forms, such as slopes, ridges, or valleys [@jasiewicz_geomorphons_2013].
 These phenotypes are used in many studies, including landslide susceptibility, ecosystem services, human mobility, and digital soil mapping. 
@@ -449,7 +394,7 @@ The original implementation of the geomorphons' algorithm was created in GRASS G
 
 ```{r, eval=FALSE}
 qgis_search_algorithms("geomorphon")
-#> [1] "grass:r.geomorphon" "sagang:geomorphons" 
+#> [1] "grass:r.geomorphon" 
 qgis_show_help("grass:r.geomorphon")
 # output not shown
 ```

--- a/15-eco.Rmd
+++ b/15-eco.Rmd
@@ -122,8 +122,7 @@ The next step is to compute variables which are not only needed for the modeling
 Specifically, we compute catchment slope and catchment area\index{catchment area} from a digital elevation model\index{digital elevation model} using R-GIS bridges (see Chapter \@ref(gis)).
 Curvatures might also represent valuable predictors, and in the Exercise section you can find out how they would impact the modeling result.
 
-To compute catchment area\index{catchment area} and catchment slope, the chapter previously used the SAGA NextGen plugin (`sagang:sagawetnessindex`), but this plugin is no longer available (see [issue #1181](https://github.com/geocompx/geocompr/issues/1181)).
-Readers are encouraged to use the GRASS GIS function `r.topidx` or the **terra** package's `terrain()` as alternatives.
+To compute catchment area\index{catchment area} and catchment slope, similar functionality is available in the SAGA GIS standalone software.
 The pre-computed environmental predictors are available in **spDataLarge** as shown below.
 
 As a convenience to the reader, we have added `ep` to **spDataLarge**:

--- a/15-eco.Rmd
+++ b/15-eco.Rmd
@@ -122,84 +122,9 @@ The next step is to compute variables which are not only needed for the modeling
 Specifically, we compute catchment slope and catchment area\index{catchment area} from a digital elevation model\index{digital elevation model} using R-GIS bridges (see Chapter \@ref(gis)).
 Curvatures might also represent valuable predictors, and in the Exercise section you can find out how they would impact the modeling result.
 
-To compute catchment area\index{catchment area} and catchment slope, we can make use of the `sagang:sagawetnessindex` function.^[Admittedly, it is a bit unsatisfying that the only way of knowing that `sagawetnessindex` computes the desired terrain attributes is to be familiar with SAGA\index{SAGA}.]
-`qgis_show_help()` returns all function\index{function} parameters and default values of a specific geoalgorithm\index{geoalgorithm}.
-Here, we present only a selection of the complete output.
-
-```{r 15-eco-5, eval=FALSE}
-# if not already done, enable the saga next generation plugin
-qgisprocess::qgis_enable_plugins("processing_saga_nextgen")
-# show help
-qgisprocess::qgis_show_help("sagang:sagawetnessindex")
-#> Saga wetness index (sagang:sagawetnessindex)
-#> ...
-#> ----------------
-#> Arguments
-#> ----------------
-#>
-#> DEM: Elevation
-#> 	Argument type:	raster
-#> 	Acceptable values:
-#> 		- Path to a raster layer
-#> ...
-#> SLOPE_TYPE: Type of Slope
-#> 	Argument type:	enum
-#> 	Available values:
-#> 		- 0: [0] local slope
-#> 		- 1: [1] catchment slope
-#> ...
-#> AREA: Catchment area
-#> 	Argument type:	rasterDestination
-#> 	Acceptable values:
-#> 		- Path for new raster layer
-#>...
-#> ----------------
-#> Outputs
-#> ----------------
-#>
-#> AREA: <outputRaster>
-#> 	Catchment area
-#> SLOPE: <outputRaster>
-#> 	Catchment slope
-#> ...
-```
-
-Subsequently, we can specify the needed parameters using R named arguments (see Section \@ref(rqgis)).
-Remember that we can use a path to a file on disk or a `SpatRaster` living in R's\index{R} global environment to specify the input raster `DEM` (see Section \@ref(rqgis)).
-Specifying 1 as the `SLOPE_TYPE` makes sure that the algorithm will return the catchment slope.
-The resulting rasters\index{raster} are saved to temporary files with an `.sdat` extension which is the native SAGA\index{SAGA} raster format.
-
-```{r 15-eco-6, eval=FALSE}
-# environmental predictors: catchment slope and catchment area
-ep = qgisprocess::qgis_run_algorithm(
-  alg = "sagang:sagawetnessindex",
-  DEM = dem,
-  SLOPE_TYPE = 1,
-  SLOPE = tempfile(fileext = ".sdat"),
-  AREA = tempfile(fileext = ".sdat"),
-  .quiet = TRUE)
-```
-
-This returns a list named `ep` containing the paths to the computed output rasters.
-Let's read-in catchment area as well as catchment slope into a multi-layer `SpatRaster` object (see Section \@ref(raster-classes)).
-Additionally, we will add two more raster objects to it, namely `dem` and `ndvi`.
-
-```{r 15-eco-7, eval=FALSE}
-# read in catchment area and catchment slope
-ep = ep[c("AREA", "SLOPE")] |>
-  unlist() |>
-  rast()
-names(ep) = c("carea", "cslope") # assign better names
-origin(ep) = origin(dem) # make sure rasters have the same origin
-ep = c(dem, ndvi, ep) # add dem and ndvi to the multi-layer SpatRaster object
-```
-
-Additionally, the catchment area\index{catchment area} values are highly skewed to the right (`hist(ep$carea)`).
-A log10-transformation makes the distribution more normal.
-
-```{r 15-eco-8, eval=FALSE}
-ep$carea = log10(ep$carea)
-```
+To compute catchment area\index{catchment area} and catchment slope, the chapter previously used the SAGA NextGen plugin (`sagang:sagawetnessindex`), but this plugin is no longer available (see [issue #1181](https://github.com/geocompx/geocompr/issues/1181)).
+Readers are encouraged to use the GRASS GIS function `r.topidx` or the **terra** package's `terrain()` as alternatives.
+The pre-computed environmental predictors are available in **spDataLarge** as shown below.
 
 As a convenience to the reader, we have added `ep` to **spDataLarge**:
 

--- a/_12-ex.Rmd
+++ b/_12-ex.Rmd
@@ -28,36 +28,14 @@ E1. Compute the following terrain attributes from the `elev` dataset loaded with
 dem = terra::rast(system.file("raster/ta.tif", package = "spDataLarge"))$elev
 
 algs = qgisprocess::qgis_algorithms()
-qgis_search_algorithms("curvature")
-alg = "sagang:slopeaspectcurvature"
-qgisprocess::qgis_show_help(alg)
-qgisprocess::qgis_get_argument_specs(alg)
-# terrain attributes (ta)
-out_nms = paste0(tempdir(), "/", c("slope", "cplan", "cprof"),
-                 ".sdat")
-args = rlang::set_names(out_nms, c("SLOPE", "C_PLAN", "C_PROF"))
-out = qgis_run_algorithm(alg, ELEVATION = dem, METHOD = 6, 
-                         UNIT_SLOPE = "[1] degree",
-                         !!!args,
-                         .quiet = TRUE
-                         )
-ta = out[names(args)] |> unlist() |> terra::rast()
-names(ta) = c("slope", "cplan", "cprof")
-# catchment area
-qgis_search_algorithms("[Cc]atchment")
-alg = "sagang:catchmentarea"
-qgis_show_help(alg)
-qgis_get_argument_specs(alg)
-carea = qgis_run_algorithm(alg,
-                           ELEVATION = dem, 
-                           METHOD = 4, 
-                           FLOW = file.path(tempdir(), "carea.sdat"))
-# transform carea
-carea = terra::rast(carea$FLOW[1])
-log10_carea = log10(carea)
-names(log10_carea) = "log10_carea"
-# add log_carea and dem to the terrain attributes
-ta = c(ta, dem, log10_carea)
+# Note: terrain attributes previously used SAGA NextGen algorithms
+# (sagang:slopeaspectcurvature, sagang:catchmentarea) which are no longer
+# available. See geocompx/geocompr#1181.
+# Use GRASS alternatives like grass7:r.slope.aspect or terra::terrain().
+# Note: terrain attributes previously used SAGA NextGen algorithms
+# (sagang:slopeaspectcurvature, sagang:catchmentarea) which are no longer
+# available. See geocompx/geocompr#1181.
+# Use GRASS alternatives like grass7:r.slope.aspect or terra::terrain().
 ```
 
 E2. Extract the values from the corresponding output rasters to the `lsl` data frame (`data("lsl", package = "spDataLarge"`) by adding new variables called `slope`, `cplan`, `cprof`, `elev` and `log_carea`.

--- a/_15-ex.Rmd
+++ b/_15-ex.Rmd
@@ -72,27 +72,16 @@ pa = vegan::decostand(comm, "pa")
 pa = pa[rowSums(pa) != 0, ]
 
 # enable plugins if not already done so
-qgisprocess::qgis_enable_plugins(c("grassprovider", "processing_saga_nextgen"))
+qgisprocess::qgis_enable_plugins("grassprovider")
 
 # compute environmental predictors (ep) catchment slope and catchment area
-ep = qgisprocess::qgis_run_algorithm(
-  alg = "sagang:sagawetnessindex",
-  DEM = dem,
-  SLOPE_TYPE = 1,
-  SLOPE = tempfile(fileext = ".sdat"),
-  AREA = tempfile(fileext = ".sdat"),
-  .quiet = TRUE)
+# Note: this previously used the SAGA NextGen plugin (sagang:sagawetnessindex)
+# which is no longer available. See geocompx/geocompr#1181.
+# Use GRASS GIS or GDAL alternatives to compute terrain attributes.
+# The previous sagang:sagawetnessindex code has been removed (see issue #1181).
+# The GRASS curvature code below still works.
+
 # read in catchment area and catchment slope
-ep = ep[c("AREA", "SLOPE")] |>
-  unlist() |>
-  terra::rast()
-# assign proper names 
-names(ep) = c("carea", "cslope")
-# make sure all rasters share the same origin
-origin(ep) = origin(dem)
-# add dem and ndvi to the multi-layer SpatRaster object
-ep = c(dem, ndvi, ep) 
-ep$carea = log10(ep$carea)
 
 # compute the curvatures
 qgis_show_help("grass7:r.slope.aspect")

--- a/code/10-qgis-raster.R
+++ b/code/10-qgis-raster.R
@@ -11,15 +11,9 @@ dem_TPI = terrain(dem, v = "TPI")
 qgis_algo = qgis_algorithms()
 grep("wetness", qgis_algo$algorithm, value = TRUE)
 
-qgis_show_help("sagang:sagawetnessindex")
-
-dem_wetness = qgis_run_algorithm("sagang:sagawetnessindex", 
-                                  DEM = dem)
-
-dem_wetness_1 = qgis_as_terra(dem_wetness$AREA)
-dem_wetness_2 = qgis_as_terra(dem_wetness$AREA_MOD)
-dem_wetness_3 = qgis_as_terra(dem_wetness$SLOPE)
-dem_wetness_4 = qgis_as_terra(dem_wetness$TWI)
+# Note: sagang:sagawetnessindex removed — SAGA NextGen plugin no longer available.
+# See geocompx/geocompr#1181.
+# Use terra::terrain() or GRASS alternatives for terrain attributes.
 
 # plot(dem_wetness_1)
 # plot(dem_wetness_2)


### PR DESCRIPTION
The `north-road/qgis-processing-saga-nextgen` repository has been deleted and the plugin has been removed from `plugins.qgis.org`, breaking all `sagang:*` algorithm usage in the book.

**Update on reasoning:**

Removing references to it was my instinct when seeing the repo had disappeared and this 'burn it down' approach is supported by Nyall's take:

> best to remove all references to it 

Source: https://github.com/r-spatial/qgisprocess/issues/235#issuecomment-4530413995

## Changes

### `10-gis.Rmd` (main chapter)

- Removed SAGA plugin from `qgis_plugins()` output table and enable call
- Removed `qgis_search_algorithms("wetness")` example and the full `sagang:sagawetnessindex` terrain analysis section
- Removed `sagang:geomorphons` from provider list output
- Kept GRASS `grass:r.geomorphon` section which still works

### `15-eco.Rmd` (chapter 15)

- Removed entire `sagang:sagawetnessindex` code section (plugin enable, help, algorithm execution, reading results)
- Replaced with note pointing to issue and alternatives

### `_12-ex.Rmd` (exercises)

- Removed `sagang:slopeaspectcurvature` and `sagang:catchmentarea` exercise code

### `_15-ex.Rmd` (exercises)

- Removed `sagang:sagawetnessindex` exercise code

### `code/10-qgis-raster.R`

- Removed `sagang:sagawetnessindex` script code

Closes #1181